### PR TITLE
added clustering timeout

### DIFF
--- a/src/diart/blocks/diarization.py
+++ b/src/diart/blocks/diarization.py
@@ -35,6 +35,7 @@ class SpeakerDiarizationConfig(base.PipelineConfig):
         normalize_embedding_weights: bool = False,
         device: torch.device | None = None,
         sample_rate: int = 16000,
+        clustering_timeout = None,
         **kwargs,
     ):
         # Default segmentation model is pyannote/segmentation
@@ -68,6 +69,7 @@ class SpeakerDiarizationConfig(base.PipelineConfig):
         self.device = device or torch.device(
             "cuda" if torch.cuda.is_available() else "cpu"
         )
+        self.clustering_timeout = clustering_timeout
 
     @property
     def duration(self) -> float:
@@ -87,9 +89,12 @@ class SpeakerDiarizationConfig(base.PipelineConfig):
 
 
 class SpeakerDiarization(base.Pipeline):
-    def __init__(self, config: SpeakerDiarizationConfig | None = None):
+    def __init__(self, config: SpeakerDiarizationConfig | None = None,time_generator : Generator = None):
         self._config = SpeakerDiarizationConfig() if config is None else config
-
+        
+        #time generator informs the clustering module of the current time
+        self.time_generator = time_generator
+        
         msg = f"Latency should be in the range [{self._config.step}, {self._config.duration}]"
         assert self._config.step <= self._config.latency <= self._config.duration, msg
 
@@ -139,11 +144,20 @@ class SpeakerDiarization(base.Pipeline):
     @property
     def config(self) -> SpeakerDiarizationConfig:
         return self._config
+    
 
     def set_timestamp_shift(self, shift: float):
         self.timestamp_shift = shift
 
     def reset(self):
+        def default_time_generator():
+            t = 0
+            while True:
+                yield t
+                t+=self._config.step
+                
+        time_generator = self.time_generator or default_time_generator()
+        
         self.set_timestamp_shift(0)
         self.clustering = OnlineSpeakerClustering(
             self.config.tau_active,
@@ -151,6 +165,8 @@ class SpeakerDiarization(base.Pipeline):
             self.config.delta_new,
             "cosine",
             self.config.max_speakers,
+            self.config.clustering_timeout or None,
+            time_generator=time_generator
         )
         self.chunk_buffer, self.pred_buffer = [], []
 

--- a/src/diart/console/benchmark.py
+++ b/src/diart/console/benchmark.py
@@ -105,6 +105,9 @@ def run():
         action="store_true",
         help=f"{argdoc.NORMALIZE_EMBEDDING_WEIGHTS}. Defaults to False",
     )
+    parser.add_argument(
+        "--clustering-timeout", default=float('inf'), type=float, help=f"time to forget a speaker, defaults to inf"
+    )
     args = parser.parse_args()
 
     # Resolve device


### PR DESCRIPTION
Our use case involves the pipeline running for an extended period of time and hearing many different speakers, to prevent all classes being occupied by speakers that are no longer present I added the option to zero out a centroid and remove it from the sets after a certain period of time.

the clustering module gets the time from a recieved time generator, which allows for real time use and benchmarks.